### PR TITLE
Adds wget dependency

### DIFF
--- a/ubuntu2004-jdk11-python3/Dockerfile
+++ b/ubuntu2004-jdk11-python3/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y && \
         python3-setuptools \
         python-setuptools \
         curl \
+        wget \
         sudo && \
     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Version 4.20 of ACS added a `wget` when packaging the build, which means it has become needed on the docker image as well. Otherwise, this error is thrown:

```
wget https://github.com/apache/cloudstack-cloudmonkey/releases/download/6.3.0/cmk.linux.x86-64 -O "debian/tmp"/usr/bin/cmk
/bin/sh: 1: wget: not found
make[1]: *** [debian/rules:80: override_dh_auto_install] Error 127
make[1]: Leaving directory '/mnt/build/cloudstack'
make: *** [debian/rules:9: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
Packaging DEB failed
```

This PR aims to add this `wget` dependency.